### PR TITLE
feat: implement-chatgpt-service

### DIFF
--- a/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptChoice.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptChoice.java
@@ -1,0 +1,8 @@
+package com.hello.slackApp.model;
+
+import lombok.Data;
+
+@Data
+public class ChatgptChoice {
+    private String text;
+}

--- a/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptRequest.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptRequest.java
@@ -1,0 +1,15 @@
+package com.hello.slackApp.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class ChatgptRequest {
+
+    private String model = "text-davinci-003";
+    private String prompt;
+    private int temperature = 1;
+
+    @SerializedName(value="max_tokens")
+    private int maxTokens = 500;
+}

--- a/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptResponse.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptResponse.java
@@ -1,0 +1,10 @@
+package com.hello.slackApp.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatgptResponse {
+    private List<ChatgptChoice> choices;
+}

--- a/src/slackAppServer/main/java/com/hello/slackApp/service/ChatgptService.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/service/ChatgptService.java
@@ -1,0 +1,75 @@
+package com.hello.slackApp.service;
+
+import com.google.gson.Gson;
+import com.hello.slackApp.model.ChatgptRequest;
+import com.hello.slackApp.model.ChatgptResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ChatgptService {
+
+    @Value("${OPEN_AI_URL}")
+    private String OPEN_AI_URL;
+
+    @Value("${OPEN_AI_KEY}")
+    private String OPEN_AI_KEY;
+
+    public String processSearch(String query) {
+
+        ChatgptRequest chatgptRequest = new ChatgptRequest();
+        chatgptRequest.setPrompt(query);
+
+
+        String url = OPEN_AI_URL;
+
+        HttpPost post = new HttpPost(url);
+        post.addHeader("Content-Type", "application/json");
+        post.addHeader("Authorization", "Bearer " + OPEN_AI_KEY);
+
+        Gson gson = new Gson();
+
+        String body = gson.toJson(chatgptRequest);
+
+        log.info("body: " + body);
+
+        try {
+            final StringEntity entity = new StringEntity(body);
+            post.setEntity(entity);
+
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout(10*1000) // 연결 타임아웃을 5000ms로 설정
+                    .setSocketTimeout(10*1000)  // 소켓 타임아웃을 5000ms로 설정
+                    .build();
+
+            try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+                 CloseableHttpResponse response = httpClient.execute(post)) {
+
+                String responseBody = EntityUtils.toString(response.getEntity());
+
+                log.info("responseBody: " + responseBody);
+
+                ChatgptResponse chatGPTResponse = gson.fromJson(responseBody, ChatgptResponse.class);
+
+                return chatGPTResponse.getChoices().get(0).getText();
+            } catch (Exception e) {
+                return "failed";
+            }
+        }
+        catch (Exception e) {
+            return "failed";
+        }
+
+
+
+    }
+}


### PR DESCRIPTION
## Summary
ChatGPT API와 서버와의 연동
chatGPT Service 코드 작성 -> 이를 통해 서버에서 chatgpt API를 활용할 수 있다.

### Before i request PR review
슬랙앱과 서버의 연결

### After this PR reviewed
Alert Scheduler 구현하기