### PR TITLE
feat: implement-alert-scheduler

### DIFF
--- a/src/slackAppServer/main/java/com/hello/slackApp/config/SlackAppConfig.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/config/SlackAppConfig.java
@@ -53,6 +53,22 @@ public class SlackAppConfig {
             ctx.respond(r -> r.responseType("in_channel").text(s));
             return ctx.ack();
         });
+        
+        app.command("/alert", (req, ctx)->{
+            SlashCommandPayload payload = req.getPayload();
+            String query = payload.getText();
+            ctx.respond(r -> r.responseType("in_channel").text("Alert 정상 등록 완료 되었습니다."));
+
+            String[] alert = query.split(" ");
+            if (alert[0].equals("insert")){
+                schedulerService.addToMap(alert);
+            }
+            if (alert[0].equals("delete")){
+                schedulerService.removeFromMap(alert[1]);
+            }
+
+            return ctx.ack();
+        });
 
         return app;
     }

--- a/src/slackAppServer/main/java/com/hello/slackApp/model/AlertSchedulerHashValue.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/AlertSchedulerHashValue.java
@@ -1,0 +1,47 @@
+package com.hello.slackApp.model;
+
+public class AlertSchedulerHashValue {
+    private String queryValue;
+    private String flag;
+    private String count;
+    private String time;
+
+    public AlertSchedulerHashValue(String queryValue, String flag, String count, String time) {
+        this.queryValue = queryValue;
+        this.flag = flag;
+        this.count = count;
+        this.time = time;
+    }
+
+    public String getQueryValue() {
+        return queryValue;
+    }
+
+    public void setQueryValue(String queryValue) {
+        this.queryValue = queryValue;
+    }
+
+    public String getFlag() {
+        return flag;
+    }
+
+    public void setFlag(String flag) {
+        this.flag = flag;
+    }
+
+    public String getCount() {
+        return count;
+    }
+
+    public void setCount(String count) {
+        this.count = count;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+}

--- a/src/slackAppServer/main/java/com/hello/slackApp/service/SchedulerService.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/service/SchedulerService.java
@@ -1,0 +1,62 @@
+package com.hello.slackApp.service;
+
+import com.hello.slackApp.model.AlertSchedulerHashValue;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class SchedulerService {
+
+    private Map<String, AlertSchedulerHashValue> map = new HashMap<>();
+    private static final int TMP_RESULT = 21;
+    private static final int TMP_CNT = 5;
+
+    @Autowired
+    private SlackAlertService slackAlertService;
+
+    @Scheduled(fixedRate = 5000) // 5초마다 실행
+    public void incrementValuesAndLog() {
+        for(String key: map.keySet()) {
+            AlertSchedulerHashValue hashValue = map.get(key);
+            checkAndUpdateHashValue(hashValue, key);
+        }
+    }
+
+    private void checkAndUpdateHashValue(AlertSchedulerHashValue hashValue, String key) {
+        String flag = hashValue.getFlag();
+        int queryValue = Integer.parseInt(hashValue.getQueryValue());
+        int count = Integer.parseInt(hashValue.getCount());
+        int time = Integer.parseInt(hashValue.getTime());
+
+        if ((flag.equals("up") && queryValue <= TMP_RESULT) || (flag.equals("down") && queryValue >= TMP_RESULT)) {
+            count++;
+            if (count >= time / TMP_CNT){
+                sendAlert(key, queryValue, flag.equals("up") ? "이상" : "이하");
+            }
+        } else {
+            count = 0;
+        }
+        hashValue.setCount(Integer.toString(count));
+        map.put(key, hashValue);
+    }
+
+    private void sendAlert(String key, int queryValue, String condition) {
+        String[] alertQuery = {key, Integer.toString(queryValue), condition, Integer.toString(TMP_RESULT)};
+        slackAlertService.sendSlackNotification(alertQuery);
+    }
+
+    // Map에 값 추가
+    public void addToMap(String[] alert) {
+        AlertSchedulerHashValue hashValue = new AlertSchedulerHashValue(alert[2], alert[3], "0", alert[4]);
+        map.put(alert[1], hashValue);
+    }
+    // Map에서 값 제거
+    public void removeFromMap(String key) {
+        map.remove(key);
+    }
+
+}

--- a/src/slackAppServer/main/java/com/hello/slackApp/service/SlackAlertService.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/service/SlackAlertService.java
@@ -1,0 +1,19 @@
+package com.hello.slackApp.service;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class SlackAlertService {
+
+    public void sendSlackNotification(String[] alertQuery) {
+        RestTemplate restTemplate = new RestTemplate();
+        String webhookUrl = "https://hooks.slack.com/services/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";
+        Map<String, String> payload = new HashMap<>();
+        payload.put("text", "Metric : " + alertQuery[0] + ", Value : " + alertQuery[1] + " /// 현재 값 " + alertQuery[3] + "이 설정 값 " + alertQuery[1] +alertQuery[2] + " 입니다");
+        restTemplate.postForEntity(webhookUrl, payload, String.class);
+    }
+}


### PR DESCRIPTION
## Summary
Alert 기능을 위한 Scheduler 구현
5초(임시) 간격으로 mock metric과 insert한 alert 목록을 비교하여 조건에 맞을 시 slack webhook을 이용하여 알람 메세지 보내는 기능 구현

### Before i request PR review
슬랙앱과 chatgpt API와의 연결

### After this PR reviewed
mock데이터 대신 실제 Prometheus 값 받아오기