### PR TITLE
feat:create promethues service and connect to slack app server

### DIFF
--- a/src/slackAppServer/main/java/com/hello/slackApp/config/SlackAppConfig.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/config/SlackAppConfig.java
@@ -1,6 +1,7 @@
 package com.hello.slackApp.config;
 
 import com.hello.slackApp.service.ChatgptService;
+import com.hello.slackApp.service.PrometheusService;
 import com.hello.slackApp.service.SlackAlertService;
 import com.hello.slackApp.service.SchedulerService;
 import com.slack.api.app_backend.slash_commands.payload.SlashCommandPayload;
@@ -29,6 +30,9 @@ public class SlackAppConfig {
     @Autowired
     private SchedulerService schedulerService;
 
+    @Autowired
+    private PrometheusService prometheusService;
+
     private static final String WAIT_MESSAGE = ":robot_face: :speech_balloon: 잠시만 기다려주세요. ChatGPT가 답변을 작성하고 있습니다.";
 
     public SlackAppConfig(Environment env) {
@@ -44,16 +48,18 @@ public class SlackAppConfig {
         app.command("/bot", (req, ctx)->{
             SlashCommandPayload payload = req.getPayload();
             String userId = "<@" + payload.getUserId() + ">";
-            String question = payload.getText();
             String query = payload.getText();
-            ctx.respond(r -> r.responseType("in_channel").text(":question: " + userId + "님의 질문 : " + question));
+            ctx.respond(r -> r.responseType("in_channel").text(":question: " + userId + "님의 질문 : " + query));
             ctx.respond(r -> r.responseType("in_channel").text(WAIT_MESSAGE));
-            String s = chatgptService.processSearch(query);
+            String gpt_resp = chatgptService.processSearch(query);
             log.info(query);
-            ctx.respond(r -> r.responseType("in_channel").text(s));
+
+            String metric_result = prometheusService.processQuery(gpt_resp);
+            ctx.respond(r -> r.responseType("in_channel").text(gpt_resp));
+            ctx.respond(r -> r.responseType("in_channel").text("요청 값은 다음과 같습니다: "+ metric_result));
             return ctx.ack();
         });
-        
+
         app.command("/alert", (req, ctx)->{
             SlashCommandPayload payload = req.getPayload();
             String query = payload.getText();

--- a/src/slackAppServer/main/java/com/hello/slackApp/service/PrometheusService.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/service/PrometheusService.java
@@ -1,0 +1,73 @@
+package com.hello.slackApp.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+public class PrometheusService {
+
+    private String prometheusUrl = "http://localhost:9090";
+
+    public String processQuery(String query) throws UnsupportedEncodingException {
+
+        // Define Prometheus HTTP API request
+        String promApiCall = "api/v1/query?query=";
+
+
+        String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8.toString());
+        String requestUrl = prometheusUrl + "/" + promApiCall + encodedQuery;
+
+        System.out.println("Prometheus REST API request: " + requestUrl);
+
+        // 1. Create HTTP request
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        RequestEntity<Void> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, URI.create(requestUrl));
+
+        // 2. Create RestTemplate
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 3. Invoke HTTP request
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
+
+        // 4. Provide response information
+        System.out.println("resp.Header: " + responseEntity.getHeaders());
+        System.out.println("resp.StatusCode: " + responseEntity.getStatusCode());
+
+        // 5. Verify the request status
+        if (responseEntity.getStatusCode() == HttpStatus.OK) {
+            String responseBody = responseEntity.getBody();
+            System.out.println("-> Response bodyString: " + responseBody);
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+                JsonNode valueNode = jsonNode
+                        .path("data")
+                        .path("result")
+                        .get(0)
+                        .path("value");
+
+                // Accessing the second element in the "value" array
+                String value = valueNode.get(1).asText();
+                System.out.println("Parsed value: " + value);
+
+                return value;
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        return "Error";
+    }
+}


### PR DESCRIPTION
## Summary
- Prometheus Service 구현
- chatGPT 응답으로 받은 promQL을 Prometheus에 전달해 metric value을 응답으로 받음.

### Before i request PR review
슬랙앱과 chatgpt API 연결, 유저의 질문을 promQ로 변환한 응답을 서버가 수신.

### After this PR reviewed
Grafana Service 구현하고 dashboard url 받아오기