### PR TITLE
fix: solve charset error in chatGPT service and upgrade model version

### DIFF
--- a/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptChoice.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptChoice.java
@@ -2,7 +2,9 @@ package com.hello.slackApp.model;
 
 import lombok.Data;
 
+import java.util.Map;
+
 @Data
 public class ChatgptChoice {
-    private String text;
+    private ChatgptMessage message;
 }

--- a/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptMessage.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptMessage.java
@@ -1,0 +1,9 @@
+package com.hello.slackApp.model;
+
+import lombok.Data;
+
+@Data
+public class ChatgptMessage {
+    String role;
+    String content;
+}

--- a/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptRequest.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/model/ChatgptRequest.java
@@ -3,12 +3,15 @@ package com.hello.slackApp.model;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatgptRequest {
 
-    private String model = "text-davinci-003";
-    private String prompt;
-    private int temperature = 1;
+    private String model = "gpt-3.5-turbo";
+    private List<Map> messages;
+    private double temperature = 0.7;
 
     @SerializedName(value="max_tokens")
     private int maxTokens = 500;

--- a/src/slackAppServer/main/java/com/hello/slackApp/service/ChatgptService.java
+++ b/src/slackAppServer/main/java/com/hello/slackApp/service/ChatgptService.java
@@ -14,6 +14,11 @@ import org.apache.http.util.EntityUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @Slf4j
 public class ChatgptService {
@@ -27,7 +32,12 @@ public class ChatgptService {
     public String processSearch(String query) {
 
         ChatgptRequest chatgptRequest = new ChatgptRequest();
-        chatgptRequest.setPrompt(query);
+        List<Map> requestMessages = new ArrayList<>();
+        HashMap<String, String> message = new HashMap<>();
+        message.put("role", "user");
+        message.put("content", query);
+        requestMessages.add(message);
+        chatgptRequest.setMessages(requestMessages);
 
 
         String url = OPEN_AI_URL;
@@ -43,7 +53,8 @@ public class ChatgptService {
         log.info("body: " + body);
 
         try {
-            final StringEntity entity = new StringEntity(body);
+            final StringEntity entity = new StringEntity(body, "UTF-8");
+            log.info("entity: " + entity);
             post.setEntity(entity);
 
             RequestConfig requestConfig = RequestConfig.custom()
@@ -60,7 +71,7 @@ public class ChatgptService {
 
                 ChatgptResponse chatGPTResponse = gson.fromJson(responseBody, ChatgptResponse.class);
 
-                return chatGPTResponse.getChoices().get(0).getText();
+                return chatGPTResponse.getChoices().get(0).getMessage().getContent();
             } catch (Exception e) {
                 return "failed";
             }
@@ -68,8 +79,6 @@ public class ChatgptService {
         catch (Exception e) {
             return "failed";
         }
-
-
 
     }
 }


### PR DESCRIPTION
## Summary
- chatGPT에게 한글로 된 질문 요청 못하는 에러 해결. HttpClient 라이브러리의 charset UTF-8로 지정. 
- chatGPT 모델 gpt-turbo-3.5로 업그레이드. 여기에 필요한 요청, 응답 코드 수정.

### Before i request PR review
chatGPT가 슬랙에서 영어로 입력한 질문만 이해. promQL로의 변환 잘 수행하지 못하는 경우 발견.

### After this PR reviewed
Grafana Loki와 연계해 에러 로그에 대한 chagGPT 응답 요청하기.