### PR TITLE
#11 feat : implement gpt cache server

### DIFF
--- a/src/gptCache/requirements.txt
+++ b/src/gptCache/requirements.txt
@@ -1,0 +1,13 @@
+# requirements.txt
+
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.0.1+cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
+torchaudio==2.0.2+cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
+torchvision==0.15.2+cpu
+
+sentence-transformers==2.2.2
+fastapi
+uvicorn[standart]
+sqlite_vss==0.1.0

--- a/src/gptCache/src/init.py
+++ b/src/gptCache/src/init.py
@@ -1,0 +1,16 @@
+import sqlite3
+import sqlite_vss
+
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer("distiluse-base-multilingual-cased-v1")
+
+db = sqlite3.connect("gptcache.db")
+db.enable_load_extension(True)
+sqlite_vss.load(db)
+
+cur = db.cursor()
+
+cur.execute("create table if not exists caches (query text, query_embedding blob, answer)")
+cur.execute("create virtual table if not exists vss_caches using vss0 (query_embedding(512))")
+db.commit()

--- a/src/gptCache/src/server.py
+++ b/src/gptCache/src/server.py
@@ -1,0 +1,89 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+
+from sentence_transformers import SentenceTransformer
+
+import sqlite3
+import sqlite_vss
+
+# model setup
+model = SentenceTransformer("distiluse-base-multilingual-cased-v1")
+distance_threshold = 0.1
+
+def get_query_embedding(query: str):
+    return model.encode([query])[0]
+
+# fastapi setup
+app = FastAPI()
+
+# sqlite setup
+def get_db_cursor():
+    db = sqlite3.connect("gptcache.db")
+    db.enable_load_extension(True)
+    sqlite_vss.load(db)
+
+    return db, db.cursor()
+
+
+# request/response format
+class Entry(BaseModel):
+    query: str
+    answer: str
+
+
+@app.get("/")
+def lookup_entries(query: str = ''):
+    print(query)
+    _, cur = get_db_cursor()
+
+    def get_nearnest_cache_row_id(query: str):
+        query_embedding = get_query_embedding(query)
+
+        nearest_cache = cur.execute(
+        """
+            select rowid
+            from vss_caches
+            where vss_search(
+                query_embedding,
+                vss_search_params (?, 5) 
+            ) and distance < ?
+        """, [query_embedding.tobytes(), distance_threshold]
+        ).fetchone()
+
+        return nearest_cache[0] if nearest_cache is not None else None
+
+
+    nearnest_cache_row_id = get_nearnest_cache_row_id(query)
+
+    if nearnest_cache_row_id is not None:
+        query, answer = cur.execute(
+        """
+            select query, answer
+            from caches
+            where rowid = ?
+        """, [nearnest_cache_row_id]
+        ).fetchone()
+
+        res = {
+            "valid": True,
+            "query": query,
+            "answer": answer
+        }
+    else:
+        res = {
+            "valid": False
+        }
+
+    return JSONResponse(res)
+
+
+@app.post("/")
+def append_new_entry(entry: Entry):
+    db, cur = get_db_cursor()
+    print(entry.query, entry.answer)
+    cur.execute("insert into caches values (?, ?, ?)", [entry.query, get_query_embedding(entry.query).tobytes(), entry.answer])
+    cur.execute("insert into vss_caches(rowid, query_embedding) select rowid, query_embedding from caches")
+    db.commit()
+
+    return {"success": True}


### PR DESCRIPTION
* distiluse-base-multilingual-cased-v1 모델을 사용해 벡터 임베딩 수행
* sqlite3 제공 vector search 사용
* distance threshold 0.1을 기본 설정
* FastAPI로 API 제공